### PR TITLE
Smart ptr

### DIFF
--- a/include/AST.hpp
+++ b/include/AST.hpp
@@ -1,6 +1,7 @@
 #ifndef __INC_AST_H
 #define __INC_AST_H
 
+#include <iostream>
 #include <vector>
 #include <memory>
 
@@ -15,6 +16,7 @@ class BinOpAST : public AST{
 
     BinOpAST(Token token);
     BinOpAST(AST *left, Token token, AST *right);
+    ~BinOpAST() = default;
 
     void accept(IVisitor &visitor);
 
@@ -28,6 +30,7 @@ class UnOpAST : public AST{
 
     UnOpAST(Token token);
     UnOpAST(Token token, AST *down);
+    ~UnOpAST() = default;
 
     void accept(IVisitor &visitor);
 
@@ -39,6 +42,7 @@ class NumberAST : public AST{
     public:
 
     NumberAST(Token token);
+    ~NumberAST() = default;
 
     void accept(IVisitor &visitor);
 };
@@ -48,12 +52,13 @@ class CompoundAST : public AST{
     public:
 
     CompoundAST();
+    ~CompoundAST() = default;
 
-    void addChild(ASTptr child);
+    void addChild(AST *child);
 
     void accept(IVisitor &visitor);
 
-    std::vector<ASTptr> children;
+    std::vector<std::unique_ptr<AST>> children;
 
 };
 
@@ -63,6 +68,7 @@ class AssignAST : public AST{
 
     AssignAST(Token token);
     AssignAST(AST *var, Token token, AST *value);
+    ~AssignAST() = default;
 
     void accept(IVisitor &visitor);
 
@@ -76,6 +82,7 @@ class VarAST : public AST{
 
     VarAST(Token token);
     VarAST(Token token, int value);
+    ~VarAST() = default;
 
     void accept(IVisitor &visitor);
 
@@ -87,6 +94,7 @@ class NoOpAST : public AST{
     public:
 
     NoOpAST(Token token);
+    ~NoOpAST() = default;
 
     void accept(IVisitor &visitor);
 };
@@ -98,6 +106,7 @@ class ProgramAST : public AST{
     public:
 
     ProgramAST(Token name, ASTptr block);
+    ~ProgramAST() = default;
     void accept(IVisitor &visitor);
 
     Token name;
@@ -106,32 +115,36 @@ class ProgramAST : public AST{
 
 class BlockAST : public AST{
     public:
-    BlockAST(std::vector<ASTptr> consts, std::vector<ASTptr> declarations, ASTptr compound);
+    BlockAST(std::vector<AST*> consts, std::vector<AST*> declarations, ASTptr compound);
+    ~BlockAST() = default;
     void accept(IVisitor &visitor);
 
-    std::vector<ASTptr> consts;
-    std::vector<ASTptr> declarations;
+    std::vector<std::unique_ptr<AST>> consts;
+    std::vector<std::unique_ptr<AST>> declarations;
     std::unique_ptr<AST> compound;
 };
 
 class VarDeclAST : public AST{
     public:
-    VarDeclAST(ASTptr var, ASTptr type);
+    VarDeclAST(ASTptr var, std::shared_ptr<AST> type);
+    ~VarDeclAST() = default;
     void accept(IVisitor &visitor);
 
     std::unique_ptr<AST> var;
-    std::unique_ptr<AST> type;
+    std::shared_ptr<AST> type;
 };
 
 class TypeSpecAST : public AST{
     public:
     TypeSpecAST(Token token);
+    ~TypeSpecAST() = default;
     void accept(IVisitor &visitor);
 };
 
 class ConstAST : public AST{
     public:
     ConstAST(ASTptr constName, ASTptr constValue);
+    ~ConstAST() = default;
     void accept(IVisitor &visitor);
 
     std::unique_ptr<AST> constName;
@@ -141,20 +154,23 @@ class ConstAST : public AST{
 class StringAST : public AST{
     public:
     StringAST(Token token);
+    ~StringAST() = default;
     void accept(IVisitor &visitor);
 };
 
 class CallAST : public AST{
     public:
-    CallAST(Token token, std::vector<ASTptr> params);
+    CallAST(Token token, std::vector<AST*> params);
+    ~CallAST() = default;
     void accept(IVisitor &visitor);
 
-    std::vector<ASTptr> params;
+    std::vector<std::unique_ptr<AST>> params;
 };
 
 class ifAST : public AST{
     public:
     ifAST(ASTptr condition, ASTptr body, ASTptr elseBody);
+    ~ifAST() = default;
     void accept(IVisitor &visitor);
 
     std::unique_ptr<AST> condition;
@@ -165,6 +181,7 @@ class ifAST : public AST{
 class whileAST : public AST{
     public:
     whileAST(ASTptr condition, ASTptr body);
+    ~whileAST() = default;
     void accept(IVisitor &visitor);
 
     std::unique_ptr<AST> condition;

--- a/include/AST.hpp
+++ b/include/AST.hpp
@@ -2,6 +2,7 @@
 #define __INC_AST_H
 
 #include <vector>
+#include <memory>
 
 #include "Token.hpp"
 
@@ -17,8 +18,8 @@ class BinOpAST : public AST{
 
     void accept(IVisitor &visitor);
 
-    AST *left;
-    AST *right;
+    std::unique_ptr<AST> left;
+    std::unique_ptr<AST> right;
 };
 
 /// @brief Узел, содержащий унарную операцию
@@ -30,7 +31,7 @@ class UnOpAST : public AST{
 
     void accept(IVisitor &visitor);
 
-    AST *down;
+    std::unique_ptr<AST> down;
 };
 
 /// @brief Узел, содержащий целое число
@@ -65,8 +66,8 @@ class AssignAST : public AST{
 
     void accept(IVisitor &visitor);
 
-    AST *var;
-    AST *value;
+    std::unique_ptr<AST> var;
+    std::unique_ptr<AST> value;
 };
 
 /// @brief Узел, содержащий переменную
@@ -100,7 +101,7 @@ class ProgramAST : public AST{
     void accept(IVisitor &visitor);
 
     Token name;
-    AST *block;
+    std::unique_ptr<AST> block;
 };
 
 class BlockAST : public AST{
@@ -110,7 +111,7 @@ class BlockAST : public AST{
 
     std::vector<ASTptr> consts;
     std::vector<ASTptr> declarations;
-    ASTptr compound;
+    std::unique_ptr<AST> compound;
 };
 
 class VarDeclAST : public AST{
@@ -118,8 +119,8 @@ class VarDeclAST : public AST{
     VarDeclAST(ASTptr var, ASTptr type);
     void accept(IVisitor &visitor);
 
-    ASTptr var;
-    ASTptr type;
+    std::unique_ptr<AST> var;
+    std::unique_ptr<AST> type;
 };
 
 class TypeSpecAST : public AST{
@@ -133,8 +134,8 @@ class ConstAST : public AST{
     ConstAST(ASTptr constName, ASTptr constValue);
     void accept(IVisitor &visitor);
 
-    ASTptr constName;
-    ASTptr constValue;
+    std::unique_ptr<AST> constName;
+    std::unique_ptr<AST> constValue;
 };
 
 class StringAST : public AST{
@@ -156,9 +157,9 @@ class ifAST : public AST{
     ifAST(ASTptr condition, ASTptr body, ASTptr elseBody);
     void accept(IVisitor &visitor);
 
-    ASTptr condition;
-    ASTptr body;
-    ASTptr elseBody;
+    std::unique_ptr<AST> condition;
+    std::unique_ptr<AST> body;
+    std::unique_ptr<AST> elseBody;
 };
 
 class whileAST : public AST{
@@ -166,8 +167,8 @@ class whileAST : public AST{
     whileAST(ASTptr condition, ASTptr body);
     void accept(IVisitor &visitor);
 
-    ASTptr condition;
-    ASTptr body;
+    std::unique_ptr<AST> condition;
+    std::unique_ptr<AST> body;
 };
 
 

--- a/include/ASTclasses.hpp
+++ b/include/ASTclasses.hpp
@@ -51,6 +51,7 @@ class AST{
 
     //AST();
     AST(Token token);
+    virtual ~AST() = default;
 
     virtual void accept(IVisitor &visitor) = 0;
 

--- a/include/Syntax.hpp
+++ b/include/Syntax.hpp
@@ -33,7 +33,7 @@ class SyntaxAnalyzer{
 
     AST *syntaxCompoundSt(void);
 
-    std::vector<ASTptr> syntaxStList(void);
+    std::vector<AST*> syntaxStList(void);
 
     ASTptr syntaxSt(void);
 
@@ -45,9 +45,9 @@ class SyntaxAnalyzer{
 
     ASTptr syntaxBlock(void);
 
-    std::vector<ASTptr> syntaxVars(void);
+    std::vector<AST*> syntaxVars(void);
 
-    std::vector<ASTptr> syntaxVarDecl(void);
+    std::vector<AST*> syntaxVarDecl(void);
 
     ASTptr syntaxTypeSpec(void);
 
@@ -73,7 +73,7 @@ class SyntaxAnalyzer{
 
     Token &lookFoward(void);
 
-    std::vector<ASTptr> syntaxConsts(void);
+    std::vector<AST*> syntaxConsts(void);
     ASTptr syntaxConstDecl(void);
 
     void eat(IToken::Type type);

--- a/main.cpp
+++ b/main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char** argv){
 //    }
 
     SyntaxAnalyzer syntax(tokens);
-    AST *root = syntax.parseTokens();
+    std::unique_ptr<AST>root(syntax.parseTokens());
 
     GraphvizVisitor graph("out.dot");
     root->accept(graph);

--- a/main.cpp
+++ b/main.cpp
@@ -14,13 +14,6 @@ std::map<std::string, int> globalVariables;
 
 #include "PascalTokens.hpp"
 
-class Variable{
-    public:
-
-    private:
-    std::variant<int, double, char, bool> value;
-};
-
 int main(int argc, char** argv){
     if(argc != 2){
         std::cout << "Пожалуйста, введите только\033[31m название исходного файла\33[0m для разбора после названия программы\n";
@@ -33,7 +26,7 @@ int main(int argc, char** argv){
 //    for(auto tok : tokens){
 //        std::cout << fmt::format("{}     {}\n", tok.getStr(), magic_enum::enum_name(tok.getType()));
 //    }
-
+    //List<Token>  tokens{{Token("PROGRAM", IToken::PROGRAM), Token("NAME", IToken::ID), Token(";", IToken::SEMI), Token("BEGIN", IToken::BEGIN), Token("END", IToken::END), Token(".", IToken::DOT), Token("$", IToken::ENDOFSTREAM)}};
     SyntaxAnalyzer syntax(tokens);
     std::unique_ptr<AST>root(syntax.parseTokens());
 

--- a/out.dot
+++ b/out.dot
@@ -1,0 +1,15 @@
+digraph name{
+n0[label="__START__"]
+n1[label="BLOCK"]
+n2[label="DEFINITION"]
+n3[label="x"]
+n4[label="INTEGER"]
+n5[label="COMPOUND"]
+n6[label="$"]
+n0->n1
+n1->n2
+n2->n3
+n2->n4
+n1->n5
+n5->n6
+}

--- a/progs/prog3.txt
+++ b/progs/prog3.txt
@@ -1,0 +1,5 @@
+PROGRAM TEST;
+VAR
+    x, y : INTEGER;
+BEGIN
+END.

--- a/run.sh
+++ b/run.sh
@@ -15,5 +15,5 @@ do
 done
 
 cd build
-./Main prog1.txt
+valgrind --leak-check=full ./Main prog1.txt
 dot out.dot -Tsvg > output.svg

--- a/run.sh
+++ b/run.sh
@@ -15,5 +15,5 @@ do
 done
 
 cd build
-valgrind --leak-check=full ./Main prog1.txt
+valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose --log-file=val-ouput.txt ./Main prog1.txt
 dot out.dot -Tsvg > output.svg

--- a/src/AST.cpp
+++ b/src/AST.cpp
@@ -35,8 +35,8 @@ void NumberAST::accept(IVisitor &visitor){
 ==================*/
 CompoundAST::CompoundAST() : AST({"COMPOUND", IToken::EMPTY}) {};
 
-void CompoundAST::addChild(ASTptr child){
-    children.push_back(child);
+void CompoundAST::addChild(AST *child){
+    children.push_back(std::unique_ptr<AST>(child));
 }
 
 void CompoundAST::accept(IVisitor &visitor){
@@ -83,11 +83,16 @@ void BlockAST::accept(IVisitor &visitor){
     visitor.visit(*this);
 }
 
-BlockAST::BlockAST(std::vector<ASTptr> consts, std::vector<ASTptr> declarations, ASTptr compound) : AST({"BLOCK", IToken::Type::BLOCK}), consts(consts), declarations(declarations), compound(compound) {};
+BlockAST::BlockAST(std::vector<AST*> consts, std::vector<AST*> declarations, ASTptr compound) : AST({"BLOCK", IToken::Type::BLOCK}), compound(compound) {
+    for(std::size_t i = 0; i < consts.size(); i++)
+        this->consts.push_back(std::unique_ptr<AST>(consts[i]));
+    for(std::size_t i = 0; i < declarations.size(); i++)
+        this->declarations.push_back(std::unique_ptr<AST>(declarations[i]));
+};
 
 /*Определения VarDeclAST
 ==================*/
-VarDeclAST::VarDeclAST(ASTptr var, ASTptr type) : AST({"DEFINITION", IToken::VARDECL}), var(var), type(type) {};
+VarDeclAST::VarDeclAST(ASTptr var, std::shared_ptr<AST> type) : AST({"DEFINITION", IToken::VARDECL}), var(var), type(type) {};
 
 void VarDeclAST::accept(IVisitor &visitor){
     visitor.visit(*this);
@@ -119,7 +124,10 @@ void StringAST::accept(IVisitor &visitor){
 
 /*Определения CallAST
 ==================*/
-CallAST::CallAST(Token token, std::vector<ASTptr> params) : AST(token), params(params){};
+CallAST::CallAST(Token token, std::vector<AST*> params) : AST(token){
+    for(std::size_t i = 0; i < params.size(); i++)
+        this->params.push_back(std::unique_ptr<AST>(params[i]));
+};
 
 void CallAST::accept(IVisitor &visitor){
     visitor.visit(*this);

--- a/src/Syntax.cpp
+++ b/src/Syntax.cpp
@@ -16,15 +16,15 @@ AST *SyntaxAnalyzer::syntaxProgram(void){
 
 ASTptr SyntaxAnalyzer::syntaxBlock(void){
     /* syntaxBlock ::= syntaxConsts* syntaxVars* syntaxCompoundSt */
-    std::vector<ASTptr> constsList = syntaxConsts();
-    std::vector<ASTptr> declsList = syntaxVars();
+    std::vector<AST*> constsList = syntaxConsts();
+    std::vector<AST*> declsList = syntaxVars();
     ASTptr compoundPTR = syntaxCompoundSt();
     return new BlockAST(constsList, declsList, compoundPTR);
 }
 
-std::vector<ASTptr> SyntaxAnalyzer::syntaxConsts(void){
+std::vector<AST*> SyntaxAnalyzer::syntaxConsts(void){
     /* syntaxConsts ::= 'CONST' (syntaxConstDecl ';')+ */
-    std::vector<ASTptr> constsList;
+    std::vector<AST*> constsList;
     if(getCurTok().getType() == IToken::CONST){
         eat(IToken::CONST);
         while(getCurTok().getType() == IToken::ID){
@@ -33,7 +33,6 @@ std::vector<ASTptr> SyntaxAnalyzer::syntaxConsts(void){
         }
     }
     return constsList;
-
 }
 
 ASTptr SyntaxAnalyzer::syntaxConstDecl(void){
@@ -57,13 +56,13 @@ ASTptr SyntaxAnalyzer::syntaxConstDecl(void){
     return new ConstAST(constNamePTR, constValPTR);
 }
 
-std::vector<ASTptr> SyntaxAnalyzer::syntaxVars(void){
+std::vector<AST*> SyntaxAnalyzer::syntaxVars(void){
     /* syntaxVars ::= 'VAR' (syntaxVarDecl ';')+ */
-    std::vector<ASTptr> declsList;
+    std::vector<AST*> declsList;
     if(getCurTok().getType() == IToken::VAR){
         eat(IToken::VAR);
         while(getCurTok().getType() == IToken::ID){
-            std::vector<ASTptr> varDeclList = syntaxVarDecl();
+            std::vector<AST*> varDeclList = syntaxVarDecl();
             for(auto varDeclPTR : varDeclList)
                 declsList.push_back(varDeclPTR);
             eat(IToken::SEMI);
@@ -72,9 +71,9 @@ std::vector<ASTptr> SyntaxAnalyzer::syntaxVars(void){
     return declsList;
 }
 
-std::vector<ASTptr> SyntaxAnalyzer::syntaxVarDecl(void){
+std::vector<AST*> SyntaxAnalyzer::syntaxVarDecl(void){
     /* syntaxVarDecl ::= ('<ID>' ','*)+ ':' syntaxTypeSpec */
-    std::vector<ASTptr> varsList;
+    std::vector<AST*> varsList;
     varsList.push_back(new VarAST(getCurTok()));
     eat(IToken::ID);
 
@@ -86,8 +85,8 @@ std::vector<ASTptr> SyntaxAnalyzer::syntaxVarDecl(void){
 
     eat(IToken::COLON);
 
-    ASTptr typeNodePTR = syntaxTypeSpec();
-    std::vector<ASTptr> varDeclsList;
+    std::shared_ptr<AST> typeNodePTR = std::shared_ptr<AST>(syntaxTypeSpec());
+    std::vector<AST*> varDeclsList;
     for(auto var : varsList){
         varDeclsList.push_back(new VarDeclAST(var, typeNodePTR));
     }
@@ -114,7 +113,7 @@ ASTptr SyntaxAnalyzer::syntaxTypeSpec(void){
 AST *SyntaxAnalyzer::syntaxCompoundSt(void){
     /* syntaxCompoundSt ::= 'BEGIN' (syntaxSt ';')* 'END' */
     eat(IToken::BEGIN);
-    std::vector<ASTptr> stList = syntaxStList();
+    std::vector<AST*> stList = syntaxStList();
     eat(IToken::END);
 
     CompoundAST *compoundPTR = new CompoundAST();
@@ -124,10 +123,11 @@ AST *SyntaxAnalyzer::syntaxCompoundSt(void){
     return compoundPTR;
 }
 
-std::vector<ASTptr> SyntaxAnalyzer::syntaxStList(void){
+std::vector<AST*> SyntaxAnalyzer::syntaxStList(void){
     AST *stPTR = syntaxSt();
 
-    std::vector<ASTptr> stList = {stPTR};
+    std::vector<AST*> stList;
+    stList.push_back(stPTR);
 
     while(getCurTok().getType() == IToken::SEMI){
         eat(getCurTok().getType());
@@ -193,7 +193,7 @@ ASTptr SyntaxAnalyzer::syntaxCallSt(void){
     Token nameTok = getCurTok();
     eat(IToken::ID);
     eat(IToken::LPAREN);
-    std::vector<ASTptr> paramsList;
+    std::vector<AST*> paramsList;
     if(getCurTok().getType() != IToken::RPAREN){
         ASTptr paramPTR = syntaxExpr();
         paramsList.push_back(paramPTR);

--- a/src/Visitor.cpp
+++ b/src/Visitor.cpp
@@ -101,7 +101,7 @@ void GraphvizVisitor::visit(CompoundAST &node){
     std::size_t backup = nodeIndex;
     declarations.push_back(std::make_pair(std::to_string(backup), node.token.getStr()));
     nodeIndex++;
-    for(auto child : node.children){
+    for(auto &child : node.children){
         links.push_back(std::make_pair(std::to_string(backup), std::to_string(nodeIndex)));
         child->accept(*this);
     }
@@ -151,11 +151,11 @@ void GraphvizVisitor::visit(BlockAST &node){
     std::size_t backup = nodeIndex;
     declarations.push_back(std::make_pair(std::to_string(backup), node.token.getStr()));
     nodeIndex++;
-    for(auto child : node.declarations){
+    for(auto &child : node.declarations){
         links.push_back(std::make_pair(std::to_string(backup), std::to_string(nodeIndex)));
         child->accept(*this);
     }
-    for(auto child : node.consts){
+    for(auto &child : node.consts){
         links.push_back(std::make_pair(std::to_string(backup), std::to_string(nodeIndex)));
         child->accept(*this);
     }
@@ -200,7 +200,7 @@ void GraphvizVisitor::visit(CallAST &node){
     std::size_t backup = nodeIndex;
     declarations.push_back(std::make_pair(std::to_string(backup), node.token.getStr()));
     nodeIndex++;
-    for(auto child : node.params){
+    for(auto &child : node.params){
         links.push_back(std::make_pair(std::to_string(backup), std::to_string(nodeIndex)));
         child->accept(*this);
     }
@@ -251,7 +251,7 @@ void TypeViewVisitor::visit(NumberAST &node){
 
 void TypeViewVisitor::visit(CompoundAST &node){
     typesStrings.push_back(node.token.getStr());
-    for(auto child : node.children){
+    for(auto &child : node.children){
         child->accept(*this);
     }
 }
@@ -277,10 +277,10 @@ void TypeViewVisitor::visit(ProgramAST &node){
 
 void TypeViewVisitor::visit(BlockAST &node){
     typesStrings.push_back(node.token.getStr());
-    for(auto child : node.consts){
+    for(auto &child : node.consts){
         child->accept(*this);
     }
-    for(auto child : node.declarations){
+    for(auto &child : node.declarations){
         child->accept(*this);
     }
     node.compound->accept(*this);
@@ -308,7 +308,7 @@ void TypeViewVisitor::visit(StringAST &node){
 
 void TypeViewVisitor::visit(CallAST &node){
     typesStrings.push_back(node.token.getStr());
-    for(auto child : node.params){
+    for(auto &child : node.params){
         child->accept(*this);
     }
 }
@@ -366,7 +366,7 @@ std::vector<std::string> TypeViewVisitor::getData(void){
     }
 
     void CodeGenVisitor::visit(CompoundAST &node){
-        for(auto child : node.children){
+        for(auto &child : node.children){
             child->accept(*this);
         }
     }
@@ -398,7 +398,7 @@ std::vector<std::string> TypeViewVisitor::getData(void){
         file << "\n";
         if(node.consts.size() != 0){
             file << ".data" << "\n";
-            for(auto child : node.consts){
+            for(auto &child : node.consts){
                 child->accept(*this);
             }
         }


### PR DESCRIPTION
Были проблемы внутри  syntaxVarDecl, т.к. каждая группа переменных делит **один и тот же указатель** на тип.
Например: x, y : INTEGER.
создается два узла абстрактного дерева синтаксиса, в каждом из которых свой указатель на переменную (x, y), но оба ссылаются на один и тот же указатель на INTEGER (typeSpecAST узел). Решено введением shared_ptr вместо unique_ptr для типов.
В целом интерфейс синтаксиса остался на простых указателях и векторах простых указателей, внутреннее устройство AST полностью на умных указателях и векторах умных указателей
Утечек нет.